### PR TITLE
Refactor and optimize media optimizer scripts

### DIFF
--- a/bin/media.sh
+++ b/bin/media.sh
@@ -13,56 +13,118 @@ readonly VID_CRF=27     # ffmpeg HEVC CRF (0-51, lower is better)
 readonly SUFFIX="_opt"  # Suffix for processed files
 
 # --- Functions ---
-# Check for required command-line tools.
-check_deps() {
-  local dep missing=0
-  for dep in rimage oxipng ffmpeg flaca; do
-    if ! command -v "$dep" >/dev/null 2>&1; then
-      echo "Error: Dependency '$dep' not found." >&2
-      missing=1
-    fi
-  done
-  ((missing)) && {
-    echo "Install via: pkg install rust imagemagick ffmpeg flac" >&2
-    exit 1
-  }
-  # rimage/oxipng are installed via `cargo` after installing `rust`.
-  # if cargo command missing, pkg install rust. If rust is installed, cargo install rimage oxipng
+# Check for command-line tool availability
+has() {
+  command -v "$1" >/dev/null 2>&1
 }
 
-# Process a single file based on its extension.
+log() {
+  printf '[%s] %s\n' "$(date '+%H:%M:%S')" "$*"
+}
+
+warn() {
+  printf 'WARNING: %s\n' "$*" >&2
+}
+
+# Check for required command-line tools
+check_deps() {
+  local missing=()
+
+  # Check for image optimization tools
+  if ! has rimage && ! has imgc && ! has image-optimizer; then
+    missing+=("rimage or imgc (cargo install rimage imgc)")
+  fi
+
+  if ! has oxipng && ! has optipng; then
+    missing+=("oxipng or optipng (cargo install oxipng OR pkg install optipng)")
+  fi
+
+  if ! has ffmpeg; then
+    missing+=("ffmpeg (pkg install ffmpeg)")
+  fi
+
+  if ! has flaca && [[ "$*" == *".flac"* ]]; then
+    warn "flaca not found, FLAC optimization will be skipped"
+  fi
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    echo "Error: Missing critical dependencies:" >&2
+    printf '  - %s\n' "${missing[@]}" >&2
+    exit 1
+  fi
+}
+
+# Process a single file based on its extension
 process_file() {
   local file=$1
   if [[ $file == *"$SUFFIX".* ]]; then
-    echo "Skipping: $file (already processed)"
-    return
+    log "Skipping: $file (already processed)"
+    return 0
   fi
 
   local name="${file%.*}"
   local ext="${file##*.}"
   local out_file="${name}${SUFFIX}.${ext}"
 
-  echo "Processing: $file"
+  log "Processing: $file"
+  local success=0
+
   case "${ext,,}" in
   jpg | jpeg | webp | avif)
-    rimage -q "$IMG_QUALITY" "$file" -o "$out_file" >/dev/null 2>&1 || :
+    # Tool preference: image-optimizer -> imgc -> rimage
+    if has image-optimizer; then
+      image-optimizer -i "$file" -o "$(dirname "$out_file")" -q "$IMG_QUALITY" 2>/dev/null && success=1
+    elif has imgc; then
+      imgc "$file" "${ext,,}" -q "$IMG_QUALITY" -o "$(dirname "$out_file")" 2>/dev/null && success=1
+    elif has rimage; then
+      rimage -q "$IMG_QUALITY" "$file" -o "$out_file" 2>/dev/null && success=1
+    else
+      warn "No suitable image optimizer found for $file"
+      return 1
+    fi
     ;;
   png)
-    oxipng -o max --strip safe "$file" --out "$out_file" >/dev/null 2>&1 || :
+    # Tool preference: oxipng -> optipng
+    if has oxipng; then
+      oxipng -o max --strip safe "$file" --out "$out_file" 2>/dev/null && success=1
+    elif has optipng; then
+      cp "$file" "$out_file" && optipng -o7 -strip all -quiet "$out_file" 2>/dev/null && success=1
+    else
+      warn "No PNG optimizer found for $file"
+      return 1
+    fi
     ;;
   mp4 | mov | mkv | webm)
-    ffmpeg -i "$file" -c:v libx265 -preset medium -crf "$VID_CRF" \
-      -c:a copy -tag:v hvc1 -y "$out_file" >/dev/null 2>&1 || :
+    if has ffmpeg; then
+      ffmpeg -i "$file" -c:v libx265 -preset medium -crf "$VID_CRF" \
+        -c:a copy -tag:v hvc1 -y "$out_file" -loglevel error 2>&1 && success=1
+    else
+      warn "ffmpeg not found, cannot process $file"
+      return 1
+    fi
     ;;
   flac)
-    # flaca is for FLAC audio, not images.
-    cp "$file" "$out_file" >/dev/null 2>&1 || :
-    flaca --best "$out_file" >/dev/null 2>&1 || :
+    if has flaca; then
+      cp "$file" "$out_file" 2>/dev/null || return 1
+      flaca --best "$out_file" 2>/dev/null && success=1
+    else
+      warn "flaca not found, skipping $file"
+      return 1
+    fi
     ;;
   *)
-    echo "Unsupported: $file"
+    warn "Unsupported file type: $file"
+    return 1
     ;;
   esac
+
+  if [[ $success -eq 1 ]]; then
+    log "Successfully optimized: $out_file"
+    return 0
+  else
+    warn "Failed to optimize: $file"
+    return 1
+  fi
 }
 
 # --- Main ---

--- a/bin/optimize
+++ b/bin/optimize
@@ -25,15 +25,15 @@ JOBS=0
 
 # --- Helper Functions ---
 log() {
-  printf '🚀 %s\\n' "$*"
+  printf '[%s] %s\\n' "$(date '+%H:%M:%S')" "$*"
 }
 
 warn() {
-  printf '⚠️ %s\\n' "$*" >&2
+  printf 'WARNING: %s\\n' "$*" >&2
 }
 
 err() {
-  printf '❌ %s\\n' "$*" >&2
+  printf 'ERROR: %s\\n' "$*" >&2
   exit 1
 }
 
@@ -103,7 +103,7 @@ optimize_single_image() {
   local original_size
   original_size=$(get_size "$file")
 
-  log "🖼️ Processing Image: $base_name"
+  log "Processing Image: $base_name"
 
   local temp_file
   temp_file=$(mktemp -p "${TMPDIR:-/tmp}" "opt-img.XXXXXX")
@@ -173,7 +173,7 @@ optimize_single_image() {
       mv "$temp_file" "$out_file"
       local saved=$((original_size - new_size))
       local percent=$((saved * 100 / original_size))
-      printf '✅ Saved %s (%s -> %s, %d%%) -> %s\n' \
+      printf 'Saved %s (%s -> %s, %d%%) -> %s\n' \
         "$(format_bytes "$saved")" \
         "$(format_bytes "$original_size")" \
         "$(format_bytes "$new_size")" \
@@ -184,9 +184,9 @@ optimize_single_image() {
       # If optimized is larger, just copy original if format is same
       if [[ $to_webp -eq 0 ]]; then
         cp "$file" "$out_file"
-        printf '➖ No savings for %s, copied original.\n' "$base_name"
+        printf 'No savings for %s, copied original.\n' "$base_name"
       else
-        printf '➖ No savings for %s, skipping.\n' "$base_name"
+        printf 'No savings for %s, skipping.\n' "$base_name"
       fi
       rm -f "$temp_file"
     fi
@@ -219,7 +219,7 @@ optimize_single_video() {
   local original_size
   original_size=$(get_size "$file")
 
-  log "🎬 Processing Video: $base_name"
+  log "Processing Video: $base_name"
 
   if ffmpeg -i "$file" -c:v libx265 -preset medium -crf "$crf" -c:a copy -tag:v hvc1 -y "$out_file" -loglevel error; then
     local new_size
@@ -227,7 +227,7 @@ optimize_single_video() {
     if ((new_size > 0 && new_size < original_size)); then
       local saved=$((original_size - new_size))
       local percent=$((saved * 100 / original_size))
-      printf '✅ Saved %s (%s -> %s, %d%%) -> %s\n' \
+      printf 'Saved %s (%s -> %s, %d%%) -> %s\n' \
         "$(format_bytes "$saved")" \
         "$(format_bytes "$original_size")" \
         "$(format_bytes "$new_size")" \
@@ -235,7 +235,7 @@ optimize_single_video() {
         "$out_file"
       [[ $keep_original -eq 0 ]] && rm -f "$file"
     else
-      printf '➖ No savings for %s. Deleting temp file.\n' "$base_name"
+      printf 'No savings for %s. Deleting temp file.\n' "$base_name"
       rm -f "$out_file"
     fi
   else
@@ -361,7 +361,7 @@ main() {
     if [[ -d $item ]]; then
       local search_path
       search_path=$(realpath "$item")
-      log "🔍 Searching in: $search_path"
+      log "Searching in: $search_path"
 
       local patterns=()
       if [[ $type == "image" || $type == "all" ]]; then
@@ -374,11 +374,22 @@ main() {
       # Remove first '-o'
       [[ ${#patterns[@]} -gt 0 ]] && patterns=("${patterns[@]:1}")
 
-      if has fd; then
+      # Use tool preference: fdf -> fd -> find
+      if has fdf; then
         local fd_exts=()
         [[ $type == "image" || $type == "all" ]] && for ext in "${image_exts//,/ }"; do fd_exts+=(-e "$ext"); done
         [[ $type == "video" || $type == "all" ]] && for ext in "${video_exts//,/ }"; do fd_exts+=(-e "$ext"); done
-        mapfile -t -d '' found_files < <(fd -0 -t f "${fd_exts[@]}" . "$search_path")
+        local max_depth_flag=()
+        [[ $recursive -eq 0 ]] && max_depth_flag=(-d 1)
+        mapfile -t -d '' found_files < <(fdf -0 -t f "${max_depth_flag[@]}" "${fd_exts[@]}" . "$search_path")
+        for f in "${found_files[@]}"; do all_files+=("$f"); done
+      elif has fd; then
+        local fd_exts=()
+        [[ $type == "image" || $type == "all" ]] && for ext in "${image_exts//,/ }"; do fd_exts+=(-e "$ext"); done
+        [[ $type == "video" || $type == "all" ]] && for ext in "${video_exts//,/ }"; do fd_exts+=(-e "$ext"); done
+        local max_depth_flag=()
+        [[ $recursive -eq 0 ]] && max_depth_flag=(-d 1)
+        mapfile -t -d '' found_files < <(fd -0 -t f "${max_depth_flag[@]}" "${fd_exts[@]}" . "$search_path")
         for f in "${found_files[@]}"; do all_files+=("$f"); done
       else
         mapfile -t found_files < <(find "$search_path" "${find_args[@]}" -type f \( "${patterns[@]}" \))
@@ -435,9 +446,16 @@ main() {
   }
   export -f process_file
 
-  printf '%s\\0' "${all_files[@]}" | xargs -0 -P "$JOBS" -I {} bash -c 'process_file "{}" "$0" "$1" "$2" "$3" "$4"' "$output_dir" "$quality" "$crf" "$to_webp" "$keep_original"
+  # Use tool preference: rust-parallel -> parallel -> xargs
+  if has rust-parallel; then
+    printf '%s\\0' "${all_files[@]}" | rust-parallel -0 -j "$JOBS" bash -c 'process_file "{}" "$0" "$1" "$2" "$3" "$4"' "$output_dir" "$quality" "$crf" "$to_webp" "$keep_original"
+  elif has parallel; then
+    printf '%s\\0' "${all_files[@]}" | parallel -0 -j "$JOBS" bash -c 'process_file "{}" "$0" "$1" "$2" "$3" "$4"' "$output_dir" "$quality" "$crf" "$to_webp" "$keep_original"
+  else
+    printf '%s\\0' "${all_files[@]}" | xargs -0 -P "$JOBS" -I {} bash -c 'process_file "{}" "$0" "$1" "$2" "$3" "$4"' "$output_dir" "$quality" "$crf" "$to_webp" "$keep_original"
+  fi
 
-  log "🎉 Optimization complete!"
+  log "Optimization complete!"
 }
 
 # Run main function if script is executed directly


### PR DESCRIPTION
This commit refactors all three media optimizer scripts (optimize, media.sh, opt.sh) to improve code quality, performance, and maintainability.

Changes:
- Applied tool preference hierarchy throughout:
  * File finding: fdf -> fd -> find
  * Parallel processing: rust-parallel -> parallel -> xargs
  * Pattern matching: rg -> grep
- Removed excessive emojis from optimize script for cleaner output
- Improved error handling in media.sh (removed silent failures)
- Added tool fallback chains for better compatibility
- Enhanced logging with timestamps
- Better dependency checking with clear error messages
- Consistent code style across all scripts

Technical improvements:
- bin/optimize: Added fdf support, improved parallel tool detection
- bin/media.sh: Replaced silent error suppression with proper error handling and tool preferences
- bin/opt.sh: Added fdf support, rg preference for grep operations, improved parallel processing

All scripts now follow modern tool preferences while maintaining backwards compatibility.