### PR TITLE
Fix shell script errors in clean.sh, optimize.sh, and common.sh

### DIFF
--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -19,7 +19,7 @@ else
 fi
 
 # Globals
-declare -g DRY_RUN=0 VERBOSE=0 HAS_SHIZUKU=0 HAS_ADB=0
+declare -g DRY_RUN=0 VERBOSE=0 HAS_SHIZUKU=0 HAS_ADB=0 PRIVILEGES_CHECKED=0
 declare -g OPT_QUICK=0 OPT_DEEP=0 OPT_WHATSAPP=0 OPT_TELEGRAM=0 OPT_ADB=0 OPT_SYSTEM_CACHE=0 OPT_PKG_CACHE=0
 
 # Help
@@ -79,7 +79,8 @@ clean_temp_files() {
   if ((DRY_RUN)); then
     log "Would clean temporary files"
   else
-    find "${HOME}/.cache" "${TMPDIR:-/tmp}" -type f -delete &>/dev/null || :
+    [[ -d "${HOME}/.cache" ]] && find "${HOME}/.cache" -type f -delete 2>/dev/null || :
+    [[ -d "${TMPDIR:-/tmp}" ]] && find "${TMPDIR:-/tmp}" -type f -delete 2>/dev/null || :
   fi
 }
 

--- a/bin/optimize.sh
+++ b/bin/optimize.sh
@@ -12,10 +12,13 @@ readonly COMMON_LIB="${LIB_DIR}/common.sh"
 if [[ -f "$COMMON_LIB" ]]; then
   # shellcheck source=../lib/common.sh
   source "$COMMON_LIB"
+else
+  echo "ERROR: Missing required library: $COMMON_LIB" >&2
+  exit 1
 fi
 
 # Globals for optimization
-declare -g QUALITY=85 VIDEO_CODEC="auto" RECURSIVE=0 KEEP_ORIGINAL=1 DRY_RUN=0
+declare -g QUALITY=85 VIDEO_CODEC="auto" RECURSIVE=0 KEEP_ORIGINAL=1 DRY_RUN=0 FORMAT=""
 
 # Help
 usage() {

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -60,9 +60,9 @@ ensure_dir() {
 
 # Get file size
 get_size() {
-  if stat -c%s "$1" &>/dev/null 2>&1; then
+  if stat -c%s "$1" 2>/dev/null; then
     stat -c%s "$1" 2>/dev/null || echo 0
-  elif stat -f%z "$1" &>/dev/null 2>&1; then
+  elif stat -f%z "$1" 2>/dev/null; then
     stat -f%z "$1" 2>/dev/null || echo 0
   else
     echo 0
@@ -318,8 +318,10 @@ sweep_home() {
   export LC_ALL=C
 
   run_find -tf -e bak -e log -e old -e tmp -u -E .git "$base" -x rm -f
-  run_find -tf -te -u -E .git "$base" -x rm -f
-  run_find -td -te -u -E .git "$base" -x rmdir
+  # Find and remove empty files
+  find "$base" -type f -empty -not -path '*/.git/*' -delete 2>/dev/null || :
+  # Find and remove empty directories
+  find "$base" -type d -empty -not -path '*/.git/*' -delete 2>/dev/null || :
   run_find -tf "${p}/share/doc" "${p}/var/cache" "${p}/share/man" -x rm -f
 
   rm -rf "${p}/share/groff/"* "${p}/share/info/"* "${p}/share/lintian/"* "${p}/share/linda/"*


### PR DESCRIPTION
- Fix undefined PRIVILEGES_CHECKED variable in clean.sh
- Fix clean_temp_files to check directory existence before find
- Fix undefined FORMAT variable in optimize.sh
- Add error handling when common.sh is missing in optimize.sh
- Fix redundant redirection in common.sh get_size function
- Replace invalid -te flag with proper empty file/directory find in sweep_home