### PR TITLE
Setup yadm for Termux and refactor scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,9 @@
 
 # Shell
 *.sh text eol=lf
+.yadm/bootstrap text eol=lf
+setup.sh text eol=lf
+bin/* text eol=lf
 *.{cmd,[cC][mM][dD]} text eol=crlf
 *.{bat,[bB][aA][tT]} text eol=crlf
 *.ps1 text eol=crlf

--- a/.yadm/README.md
+++ b/.yadm/README.md
@@ -1,0 +1,86 @@
+# Yadm Configuration for Termux
+
+This directory contains yadm configuration files for managing dotfiles in Termux on Android.
+
+## Files
+
+- **bootstrap**: Bootstrap script that runs after `yadm clone --bootstrap`
+- **config**: Yadm configuration settings
+- **README.md**: This file
+
+## Usage
+
+### First-time setup
+
+```bash
+# Clone the dotfiles repository with yadm
+yadm clone --bootstrap https://github.com/Ven0m0/dot-termux.git
+```
+
+The bootstrap script will automatically:
+1. Set up directory structure
+2. Generate SSH keys if needed
+3. Configure Zsh
+4. Set up Sheldon plugins
+5. Make bin scripts executable
+6. Apply Termux-specific settings
+
+### Update dotfiles
+
+```bash
+# Pull latest changes
+yadm pull --rebase
+
+# Or use the setup script
+bash ~/setup.sh
+```
+
+### Manage dotfiles
+
+```bash
+# Check status
+yadm status
+
+# Add files
+yadm add <file>
+
+# Commit changes
+yadm commit -m "message"
+
+# Push changes
+yadm push
+```
+
+## Bootstrap Script
+
+The bootstrap script (`.yadm/bootstrap`) automatically runs when you clone with the `--bootstrap` flag. It:
+
+- Creates necessary directories (.ssh, bin, .config, etc.)
+- Generates SSH keys
+- Sets up Zsh as default shell
+- Compiles Zsh configuration files
+- Locks Sheldon plugins
+- Makes bin scripts executable
+- Applies Termux-specific settings
+
+## Ignore Patterns
+
+Files matching patterns in `.yadmignore` are not tracked by yadm. This includes:
+
+- Log files
+- Cache directories
+- SSH keys
+- Shell history
+- Compiled files
+- Temporary files
+
+## Alt Files
+
+Yadm supports alternate files for different environments using the `##` syntax:
+
+```
+.bashrc##class.Termux
+.bashrc##os.Linux
+```
+
+These allow you to maintain different versions of the same file for different systems.

--- a/.yadm/bootstrap
+++ b/.yadm/bootstrap
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Yadm bootstrap script for Termux dotfiles setup
+# This script runs automatically after 'yadm clone --bootstrap'
+set -euo pipefail
+
+# ============================================================================
+# HELPERS
+# ============================================================================
+has() { command -v "$1" &>/dev/null; }
+info() { printf '\033[32m[INFO]\033[0m %s\n' "$*"; }
+warn() { printf '\033[33m[WARN]\033[0m %s\n' "$*"; }
+err() { printf '\033[31m[ERROR]\033[0m %s\n' "$*" >&2; }
+step() { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
+
+# ============================================================================
+# ENVIRONMENT SETUP
+# ============================================================================
+export LC_ALL=C LANG=C
+HOME="${HOME:-/data/data/com.termux/files/home}"
+XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
+
+# Ensure directories exist
+mkdir -p "$HOME/.ssh" "$HOME/bin" "$HOME/.termux"
+mkdir -p "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME"
+chmod 700 "$HOME/.ssh"
+
+# ============================================================================
+# SYMLINK BIN SCRIPTS
+# ============================================================================
+step "Setting up bin scripts"
+if [[ -d $HOME/bin ]]; then
+  # Find all executable files in $HOME/bin and ensure they're executable
+  while IFS= read -r -d '' script; do
+    chmod +x "$script"
+    info "Made executable: ${script##*/}"
+  done < <(find "$HOME/bin" -type f -print0)
+fi
+
+# ============================================================================
+# SSH KEY SETUP
+# ============================================================================
+step "Setting up SSH key"
+if [[ ! -f $HOME/.ssh/id_rsa ]]; then
+  ssh-keygen -t rsa -b 4096 -f "$HOME/.ssh/id_rsa" -N "" &>/dev/null
+  info "Generated SSH key: $HOME/.ssh/id_rsa"
+else
+  info "SSH key already exists"
+fi
+
+# ============================================================================
+# ZSH SETUP
+# ============================================================================
+step "Setting up Zsh"
+if has zsh; then
+  # Set Zsh as default shell if not already
+  if [[ ${SHELL##*/} != zsh ]]; then
+    chsh -s zsh 2>/dev/null || warn "Failed to set Zsh as default shell"
+  fi
+
+  # Compile Zsh files for faster loading
+  if [[ -f $HOME/.zshrc ]]; then
+    zsh -c 'autoload -Uz zrecompile; for f in ~/.zshrc ~/.zshenv ~/.p10k.zsh; do [[ -f $f ]] && zrecompile -pq "$f"; done' &>/dev/null || :
+    info "Compiled Zsh configuration files"
+  fi
+else
+  warn "Zsh not found, skipping Zsh setup"
+fi
+
+# ============================================================================
+# SHELDON PLUGIN MANAGER
+# ============================================================================
+step "Setting up Sheldon"
+if has sheldon; then
+  sheldon lock &>/dev/null || warn "Failed to lock Sheldon plugins"
+  info "Sheldon plugins locked"
+else
+  warn "Sheldon not found, skipping plugin setup"
+fi
+
+# ============================================================================
+# TERMUX SPECIFIC SETUP
+# ============================================================================
+if [[ -n ${TERMUX_VERSION:-} ]] || [[ -d /data/data/com.termux ]]; then
+  step "Termux-specific setup"
+
+  # Reload Termux settings if font was installed
+  if has termux-reload-settings && [[ -f $HOME/.termux/font.ttf ]]; then
+    termux-reload-settings
+    info "Reloaded Termux settings"
+  fi
+
+  # Setup storage access
+  if has termux-setup-storage && [[ ! -d $HOME/storage ]]; then
+    warn "Run 'termux-setup-storage' manually to grant storage access"
+  fi
+fi
+
+# ============================================================================
+# FINALIZE
+# ============================================================================
+step "Bootstrap complete"
+info "Dotfiles successfully installed!"
+info "Please restart your shell or run: exec \$SHELL"
+
+# Display welcome message
+if [[ -f $HOME/.welcome.msg ]]; then
+  cat "$HOME/.welcome.msg"
+fi

--- a/.yadm/config
+++ b/.yadm/config
@@ -1,0 +1,25 @@
+# Yadm configuration for Termux dotfiles
+# See: https://yadm.io/docs/configuration
+
+[yadm]
+	# Automatically bootstrap on clone
+	auto-bootstrap = true
+
+	# Use alt templates for environment-specific configs
+	auto-alt = true
+
+[core]
+	# Use gitignore-style patterns
+	excludesfile = ~/.yadmignore
+
+[status]
+	# Show untracked files
+	showUntrackedFiles = all
+
+[push]
+	# Push to current branch by default
+	default = current
+
+[pull]
+	# Use rebase by default
+	rebase = true

--- a/.yadmignore
+++ b/.yadmignore
@@ -1,0 +1,66 @@
+# Yadm ignore patterns for Termux dotfiles
+# Files and directories that should NOT be managed by yadm
+
+# Logs and temporary files
+*.log
+*.tmp
+*.bak
+*~
+termux_setup.log
+
+# Cache directories
+.cache/
+**/.cache/
+
+# Local data
+.local/share/
+.local/state/
+
+# Compiled Python files
+*.pyc
+__pycache__/
+
+# Node modules
+node_modules/
+
+# Cargo build artifacts
+target/
+.cargo/registry/
+.cargo/git/
+
+# SSH keys (managed separately)
+.ssh/id_*
+.ssh/known_hosts
+
+# Shell history
+.bash_history
+.zsh_history
+.python_history
+
+# Editor swap files
+*.swp
+*.swo
+.*.sw?
+
+# Compiled Zsh files (auto-generated)
+*.zwc
+
+# Sheldon lock file (auto-generated)
+.config/sheldon/lock.toml
+
+# Termux app-specific
+.termux/boot/
+
+# Git directories (for repos in $HOME)
+.git/
+**/.git/
+
+# Storage symlink (Termux-specific)
+storage/
+
+# MacOS
+.DS_Store
+
+# Misc
+.vscode/
+.idea/

--- a/bin/media-opt
+++ b/bin/media-opt
@@ -4,13 +4,8 @@
 set -euo pipefail; shopt -s nullglob globstar
 IFS=$'\n\t'; export LC_ALL=C LANG=C
 
-# ---- Source common library ----
+# ---- Script metadata ----
 readonly SCRIPT_DIR="$(builtin cd -P -- "$(dirname -- "${BASH_SOURCE[0]:-}")" && pwd)"
-readonly LIB_DIR="${SCRIPT_DIR%/*}/lib"
-if [[ -f "${LIB_DIR}/common.sh" ]]; then
-  # shellcheck source=../lib/common.sh
-  source "${LIB_DIR}/common.sh"
-fi
 
 # ---- Environment Detection ----
 if [[ -n ${TERMUX_VERSION:-} || -d /data/data/com.termux ]]; then


### PR DESCRIPTION
- Add complete yadm configuration:
  - .yadm/bootstrap: Auto-setup script for post-clone initialization
  - .yadm/config: Yadm settings with auto-bootstrap and auto-alt
  - .yadm/README.md: Documentation for yadm usage
  - .yadmignore: Ignore patterns for cache, logs, and temp files

- Fix setup.sh:
  - Remove stow logic for non-existent directories (zsh, termux, p10k)
  - Fix bin symlink logic to work with scripts without .sh extension
  - Add safety checks for termux-setup-storage and termux-change-repo

- Fix bin/media-opt:
  - Remove reference to non-existent lib/common.sh

- Update .gitattributes:
  - Ensure correct line endings for bootstrap, setup.sh, and bin scripts
  - All shell scripts use LF (Unix) line endings

All scripts verified with bash syntax checks. Fully compatible with Termux on Android.