### PR TITLE
Add mise activation to .bashrc for Termux

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -226,6 +226,9 @@ if has zoxide; then
   ifsource "$HOME/.config/bash/zoxide.bash" && eval "$(zoxide init bash)"
 fi
 
+# Mise (version manager)
+has mise && eval "$(mise activate bash)"
+
 # Aliases
 alias ..='cd ..' ...='cd ../..' ....='cd ../../..' .....='cd ../../../..' ......='cd ../../../../..' bd='cd "$OLDPWD"' cd-="cd -" home='cd ~'
 alias dirs='dirs -v'


### PR DESCRIPTION
Added mise activation in .bashrc to match the zsh configuration, ensuring mise is properly initialized when using bash shell in Termux. This fixes the issue where mise was not accessible even with full path.