### PR TITLE
Merge shell function files into main rc files

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -134,6 +134,34 @@ fe(){ local -a files; local q="${*:-}" preview; if (( $+commands[bat] )); then p
 }
 h(){ curl -s "cheat.sh/${@:-}"; }
 
+# Quick clean utility
+quick-clean() {
+  pkg clean && pkg autoclean
+  command -v apt &>/dev/null && {
+    apt clean; apt autoclean
+  }
+  rm -f "$HOME"/.zcompdump* &>/dev/null
+  rm -f "${XDG_CACHE_HOME:-$HOME/.cache}"/.zcompdump* &>/dev/null
+  find "$HOME" -type f -name "*.log" -mtime +7 -delete
+  find "$HOME" -type d -empty -delete && find "$HOME" -type f -empty -delete
+  printf 'Quick clean finished\n'
+}
+
+# Revancify bootstrapper
+revancify() {
+  if [[ -f $HOME/revancify-xisr/revancify.sh ]]; then
+    bash "$HOME/revancify-xisr/revancify.sh"
+  else
+    curl -sL https://github.com/Xisrr1/Revancify-Xisr/raw/main/install.sh | bash
+  fi
+}
+
+# Simplify bootstrapper
+simplify() {
+  [[ -f $HOME/.Simplify.sh ]] || curl -sL -o "$HOME/.Simplify.sh" "https://raw.githubusercontent.com/arghya339/Simplify/main/Termux/Simplify.sh"
+  bash "$HOME/.Simplify.sh"
+}
+
 # ===== Integrations & finalize =====
 ifsource ~/.p10k.zsh
 has zoxide && eval "$(zoxide init zsh --cmd cd)"


### PR DESCRIPTION
Merged .config/bash/bash_functions.bash into .bashrc and .config/zsh/other.zsh into .zshrc to consolidate shell configuration. Removed external sourcing and integrated all functions directly into the main shell configuration files.

Changes:
- .bashrc: Added fe(), fcd(), faf(), fzf-man() functions and edit/pager aliases
- .zshrc: Added quick-clean(), revancify(), and simplify() functions
- Removed sourcing of bash_functions.bash from .bashrc