### PR TITLE
Refactor: Simplify setup.sh and bin scripts

### DIFF
--- a/bin/clean
+++ b/bin/clean
@@ -94,6 +94,29 @@ detect_privileges() {
 }
 
 # ============================================================================
+# HELPERS
+# ============================================================================
+# Unified file removal wrapper
+rm_files() {
+  local path=$1; shift
+  [[ ! -d $path ]] && return 0
+  if has fd; then
+    fd -tf "$@" . "$path" -X rm -f &>/dev/null || :
+  else
+    local find_args=()
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        -e) find_args+=(-name "*.$2"); shift 2;;
+        --changed-before) find_args+=(-mtime "+${2%d}"); shift 2;;
+        -g) find_args+=(-name "$2"); shift 2;;
+        *) shift;;
+      esac
+    done
+    find "$path" -type f "${find_args[@]}" -delete &>/dev/null || :
+  fi
+}
+
+# ============================================================================
 # CLEANING FUNCTIONS
 # ============================================================================
 clean_pkg_cache() {
@@ -136,34 +159,19 @@ clean_quick() {
 
   log "Cleaning temp files"
   [[ $DRY_RUN -eq 0 ]] && {
-    if has fd; then
-      [[ -d ${HOME}/.cache ]] && fd -tf . "${HOME}/.cache" -X rm -f &>/dev/null || :
-      [[ -d ${HOME}/tmp ]] && fd -tf . "${HOME}/tmp" -X rm -f &>/dev/null || :
-      fd -tf --owner "$(id -u)" . "${TMPDIR:-/tmp}" -X rm -f &>/dev/null || :
-      [[ -d /data/data/com.termux/files/home/.cache ]] && fd -tf . /data/data/com.termux/files/home/.cache/ -X rm -f &>/dev/null || :
-      [[ -d /data/data/com.termux/cache ]] && fd -tf . /data/data/com.termux/cache -X rm -f &>/dev/null || :
-      [[ -d /data/data/com.termux/files/home/tmp ]] && fd -tf . /data/data/com.termux/files/home/tmp/ -X rm -f &>/dev/null || :
-      [[ -d /data/data/com.termux/files/home ]] && fd -tf -e bak -e log . /data/data/com.termux/files/home/ -X rm -f &>/dev/null || :
-    else
-      [[ -d ${HOME}/.cache ]] && find "${HOME}/.cache" -type f -delete &>/dev/null || :
-      [[ -d ${HOME}/tmp ]] && find "${HOME}/tmp" -type f -delete &>/dev/null || :
+    for dir in "${HOME}/.cache" "${HOME}/tmp" "/data/data/com.termux/files/home/.cache" \
+               "/data/data/com.termux/cache" "/data/data/com.termux/files/home/tmp"; do
+      rm_files "$dir"
+    done
+    rm_files "/data/data/com.termux/files/home" -e bak -e log
+    has fd && fd -tf --owner "$(id -u)" . "${TMPDIR:-/tmp}" -X rm -f &>/dev/null || \
       find "${TMPDIR:-/tmp}" -type f -user "$(id -u)" -delete &>/dev/null || :
-      [[ -d /data/data/com.termux/files/home/.cache ]] && find /data/data/com.termux/files/home/.cache/ -type f -delete &>/dev/null || :
-      [[ -d /data/data/com.termux/cache ]] && find /data/data/com.termux/cache -type f -delete &>/dev/null || :
-      [[ -d /data/data/com.termux/files/home/tmp ]] && find /data/data/com.termux/files/home/tmp/ -type f -delete &>/dev/null || :
-      [[ -d /data/data/com.termux/files/home ]] && find /data/data/com.termux/files/home/ -type f \( -name "*.bak" -o -name "*.log" \) -delete &>/dev/null || :
-    fi
   }
 
   log "Cleaning log files"
   [[ $DRY_RUN -eq 0 ]] && {
-    if has fd; then
-      fd -tf -e log --changed-before 7d . "$HOME" -X rm -f &>/dev/null || :
-      fd -tf -e bak . "$HOME" -X rm -f &>/dev/null || :
-    else
-      find -O2 "$HOME" -type f -name "*.log" -mtime +7 -delete &>/dev/null || :
-      find -O2 "$HOME" -type f -name "*.bak" -delete &>/dev/null || :
-    fi
+    rm_files "$HOME" -e log --changed-before 7d
+    rm_files "$HOME" -e bak
   }
 
   log "Cleaning empty directories"
@@ -188,26 +196,13 @@ clean_deep() {
     find "$PWD" -xtype l -delete &>/dev/null || :
   fi
   log "Cleaning downloads"
-  if [[ -d "$HOME/storage/shared/Download" ]]; then
-    [[ $DRY_RUN -eq 0 ]] && {
-      if has fd; then
-        fd -tf --changed-before 60d . "$HOME/storage/shared/Download" -X rm -f &>/dev/null || :
-      else
-        find "$HOME/storage/shared/Download" -type f -mtime +60 -delete &>/dev/null || :
-      fi
-    }
-  fi
+  [[ $DRY_RUN -eq 0 ]] && rm_files "$HOME/storage/shared/Download" --changed-before 60d
+
   log "Cleaning old files in home"
   [[ $DRY_RUN -eq 0 ]] && {
-    if has fd; then
-      fd -tf -e tmp . "$HOME" -X rm -f &>/dev/null || :
-      fd -tf -g '*~' . "$HOME" -X rm -f &>/dev/null || :
-      fd -tf -g 'core' . "$HOME" -X rm -f &>/dev/null || :
-    else
-      find "$HOME" -type f -name "*.tmp" -delete &>/dev/null || :
-      find "$HOME" -type f -name "*~" -delete &>/dev/null || :
-      find "$HOME" -type f -name "core" -delete &>/dev/null || :
-    fi
+    rm_files "$HOME" -e tmp
+    rm_files "$HOME" -g '*~'
+    rm_files "$HOME" -g 'core'
   }
   info "Deep clean complete"
 }
@@ -215,32 +210,16 @@ clean_deep() {
 clean_whatsapp() {
   print_step "Cleaning WhatsApp media"
   local storage_path="${HOME}/storage/shared"
-  [[ ! -d $storage_path ]] && {
-    warn "Storage not accessible. Run: termux-setup-storage"
-    return 1
-  }
-  local -a paths=(
-    "$storage_path/WhatsApp/Media/.Statuses"
-    "$storage_path/WhatsApp/Media/WhatsApp Documents"
-    "$storage_path/WhatsApp/Media/WhatsApp Images"
-    "$storage_path/WhatsApp/Media/WhatsApp Video"
-    "$storage_path/WhatsApp/Media/WhatsApp Audio"
-  )
+  [[ ! -d $storage_path ]] && { warn "Storage not accessible. Run: termux-setup-storage"; return 1; }
 
-  local path count
+  local -a paths=("$storage_path/WhatsApp/Media/".{Statuses,"WhatsApp "{Documents,Images,Video,Audio}})
   for path in "${paths[@]}"; do
     [[ ! -d $path ]] && continue
     log "Cleaning: $path"
-    if [[ $DRY_RUN -eq 1 ]]; then
-      if has fd; then
-        count=$(fd -tf --changed-before 30d . "$path" 2>/dev/null | wc -l)
-      else count=$(find "$path" -type f -mtime +30 2>/dev/null | wc -l); fi
+    [[ $DRY_RUN -eq 1 ]] && {
+      local count=$(has fd && fd -tf --changed-before 30d . "$path" 2>/dev/null | wc -l || find "$path" -type f -mtime +30 2>/dev/null | wc -l)
       info "Would delete $count files from $path"
-    else
-      if has fd; then
-        fd -tf --changed-before 30d . "$path" -X rm -f &>/dev/null || :
-      else find "$path" -type f -mtime +30 -delete &>/dev/null || :; fi
-    fi
+    } || rm_files "$path" --changed-before 30d
   done
   info "WhatsApp cleaning complete"
 }
@@ -248,31 +227,16 @@ clean_whatsapp() {
 clean_telegram() {
   print_step "Cleaning Telegram media"
   local storage_path="${HOME}/storage/shared"
-  [[ ! -d $storage_path ]] && {
-    warn "Storage not accessible. Run: termux-setup-storage"
-    return 1
-  }
-  local -a paths=(
-    "$storage_path/Telegram/Telegram Images"
-    "$storage_path/Telegram/Telegram Video"
-    "$storage_path/Telegram/Telegram Documents"
-    "$storage_path/Telegram/Telegram Audio"
-  )
+  [[ ! -d $storage_path ]] && { warn "Storage not accessible. Run: termux-setup-storage"; return 1; }
 
-  local path count
+  local -a paths=("$storage_path/Telegram/Telegram "{Images,Video,Documents,Audio})
   for path in "${paths[@]}"; do
     [[ ! -d $path ]] && continue
     log "Cleaning: $path"
-    if [[ $DRY_RUN -eq 1 ]]; then
-      if has fd; then
-        count=$(fd -tf --changed-before 30d . "$path" 2>/dev/null | wc -l)
-      else count=$(find "$path" -type f -mtime +30 2>/dev/null | wc -l); fi
+    [[ $DRY_RUN -eq 1 ]] && {
+      local count=$(has fd && fd -tf --changed-before 30d . "$path" 2>/dev/null | wc -l || find "$path" -type f -mtime +30 2>/dev/null | wc -l)
       info "Would delete $count files from $path"
-    else
-      if has fd; then
-        fd -tf --changed-before 30d . "$path" -X rm -f &>/dev/null || :
-      else find "$path" -type f -mtime +30 -delete &>/dev/null || :; fi
-    fi
+    } || rm_files "$path" --changed-before 30d
   done
   info "Telegram cleaning complete"
 }

--- a/bin/media-opt
+++ b/bin/media-opt
@@ -40,11 +40,9 @@ cache_tool(){
 has(){ cache_tool "$1"; }
 
 # Pre-cache critical tools once at startup
-for tool in fd:fdfind rg:grep sk:fzf eza:ls rust-parallel:parallel ffzap:ffmpeg \
-            oxipng pngquant jpegoptim cjpeg flaca rimage cwebp avifenc cjxl \
-            gifsicle svgo scour opusenc identify; do
-  IFS=: read -r name fallback <<<"$tool"
-  cache_tool "$name" "$fallback" || :
+for tool in fd:fdfind rg:grep sk:fzf rust-parallel:parallel ffzap:ffmpeg oxipng pngquant jpegoptim \
+            cjpeg flaca rimage cwebp avifenc cjxl gifsicle svgo scour opusenc identify; do
+  IFS=: read -r name fallback <<<"$tool:"; cache_tool "$name" "${fallback:--}" || :
 done
 
 # ---- Helpers ----
@@ -112,11 +110,11 @@ ffmpeg_has_encoder(){
 detect_video_codec(){
   local req=${VIDEO_CODEC,,}
   [[ -n $req && $req != "auto" ]] && { VIDEO_CODEC=$req; return; }
-  if ffmpeg_has_encoder libsvtav1 || ffmpeg_has_encoder libaom-av1; then VIDEO_CODEC="av1"
-  elif ffmpeg_has_encoder libvpx-vp9; then VIDEO_CODEC="vp9"
-  elif ffmpeg_has_encoder libx265; then VIDEO_CODEC="h265"
-  elif ffmpeg_has_encoder libx264; then VIDEO_CODEC="h264"
-  else VIDEO_CODEC="vp9"; fi
+  for codec in "libsvtav1:av1" "libaom-av1:av1" "libvpx-vp9:vp9" "libx265:h265" "libx264:h264"; do
+    IFS=: read -r enc name <<<"$codec"
+    ffmpeg_has_encoder "$enc" && { VIDEO_CODEC="$name"; return; }
+  done
+  VIDEO_CODEC="vp9"
 }
 
 # ---- Backup ----
@@ -426,9 +424,12 @@ process_file(){
     *) warn "Unsupported: $file"; ((STATS_SKIPPED++));;
   esac
 }
-export -f process_file optimize_image optimize_video optimize_audio optimize_png optimize_jpeg
-export -f get_output_path is_already_optimized mkbackup cache_tool select_image_target_format ffmpeg_has_encoder
-export -f format_bytes get_size log warn show_progress
+
+# Export only essential functions for parallel execution
+for func in process_file optimize_{image,video,audio,png,jpeg} get_output_path is_already_optimized \
+            mkbackup cache_tool select_image_target_format ffmpeg_has_encoder format_bytes get_size log warn show_progress; do
+  export -f "$func" 2>/dev/null || :
+done
 
 # ---- File Collection ----
 find_media_files(){

--- a/bin/rxfetch
+++ b/bin/rxfetch
@@ -1,74 +1,26 @@
 #!/data/data/com.termux/files/usr/bin/env bash
 
-magenta="\033[1;35m"
-green="\033[1;32m"
-white="\033[1;37m"
-blue="\033[1;34m"
-red="\033[1;31m"
-black="\033[1;40;30m"
-yellow="\033[1;33m"
-cyan="\033[1;36m"
-reset="\033[0m"
-bgyellow="\033[1;43;33m"
-bgwhite="\033[1;47;37m"
-c0=${reset}
-c1=${magenta}
-c2=${green}
-c3=${white}
-c4=${blue}
-c5=${red}
-c6=${yellow}
-c7=${cyan}
-c8=${black}
-c9=${bgyellow}
-c10=${bgwhite}
+c0="\033[0m" c1="\033[1;35m" c2="\033[1;32m" c3="\033[1;37m" c4="\033[1;34m"
+c5="\033[1;31m" c6="\033[1;33m" c7="\033[1;36m" c8="\033[1;40;30m"
+c9="\033[1;43;33m" c10="\033[1;47;37m"
 
-getCodeName() { codename="$(getprop ro.product.board)"; }
-getClientBase() { client_base="$(getprop ro.com.google.clientidbase)"; }
-getModel() { model="$(getprop ro.product.brand) $(getprop ro.product.model)"; }
-getDistro() { os="$(uname -o) $(uname -m)"; }
-getKernel() { kernel="$(uname -r)"; }
-getTotalPackages() {
-  package_manager="$(which {apt,dpkg} 2>/dev/null | grep -v "not found" | awk -F/ 'NR==1{print $NF}')"
-  case "$package_manager" in
-  "apt") packages=$(apt list --installed 2>/dev/null | wc -l) ;;
-  "dpkg") packages=$(dpkg-query -l | wc -l) ;;
-  "") packages="Unknown" ;;
-  esac
-}
-getShell() { shell="$(basename "$SHELL")"; }
-getUptime() { uptime="$(uptime --pretty | sed 's/up//')"; }
-getMemoryUsage() {
-  #memory="$(free --mega | sed -n -E '2s/^[^0-9]*([0-9]+) *([0-9]+).*/'"${space}"'\2 \/ \1MB/p')"
-  _MEM="Mem:"
-  _GREP_ONE_ROW="$(free --mega | grep "$_MEM")"
-  _TOTAL="$(echo "$_GREP_ONE_ROW" | awk '{print $2}')"
-  _USED="$(echo "$_GREP_ONE_ROW" | awk '{print $3}')"
-  memory="${_USED}MB / ${_TOTAL}MB"
-}
-getDiskUsage() {
-  _MOUNTED_ON="/data"
-  _GREP_ONE_ROW="$(df -h | grep "$_MOUNTED_ON")"
-  _SIZE="$(echo "$_GREP_ONE_ROW" | awk '{print $2}')"
-  _USED="$(echo "$_GREP_ONE_ROW" | awk '{print $3}')"
-  _AVAIL="$(echo "$_GREP_ONE_ROW" | awk '{print $4}')"
-  _USE="$(echo "$_GREP_ONE_ROW" | awk '{print $5}' | sed 's/%//')"
-  _MOUNTED="$(echo "$_GREP_ONE_ROW" | awk '{print $6}')"
-  storage="${_USED}B / ${_SIZE}B = ${_AVAIL}B (${_USE}%)"
-}
-main() {
-  getCodeName
-  getClientBase
-  getModel
-  getDistro
-  getKernel
-  getTotalPackages
-  getShell
-  getUptime
-  getMemoryUsage
-  getDiskUsage
-}
-main
+# Gather system info
+codename="$(getprop ro.product.board)"
+client_base="$(getprop ro.com.google.clientidbase)"
+model="$(getprop ro.product.brand) $(getprop ro.product.model)"
+os="$(uname -o) $(uname -m)"
+kernel="$(uname -r)"
+packages=$(command -v apt &>/dev/null && apt list --installed 2>/dev/null | wc -l || dpkg-query -l 2>/dev/null | wc -l || echo "Unknown")
+shell="$(basename "$SHELL")"
+uptime="$(uptime --pretty | sed 's/up//')"
+
+# Memory usage
+mem_info="$(free --mega | grep "Mem:")"
+memory="$(echo "$mem_info" | awk '{print $3}')MB / $(echo "$mem_info" | awk '{print $2}')MB"
+
+# Disk usage
+disk_info="$(df -h | grep "/data")"
+storage="$(echo "$disk_info" | awk '{print $3"B / "$2"B = "$4"B ("$5")"}')"
 
 echo -e "\n\n"
 echo -e "  ┏━━━━━━━━━━━━━━━━━━━━━━┓"

--- a/bin/supershell
+++ b/bin/supershell
@@ -57,21 +57,13 @@ done
   exit 1
 }
 
-adb reverse "localabstract:${ADB_PORT}" tcp:5555 2>/dev/null || :
-adb connect "$adb_address" 2>/dev/null || :
-adb reverse "localabstract:${ADB_PORT}" tcp:5555 2>/dev/null || :
-adb tcpip 5555 2>/dev/null || :
-adb devices
-adb connect "${adb_ip}:5555" 2>/dev/null || :
+# Setup ADB connection
+for cmd in "reverse localabstract:${ADB_PORT} tcp:5555" "connect $adb_address" "tcpip 5555" "connect ${adb_ip}:5555"; do
+  adb $cmd 2>/dev/null || :
+done
 
-if adb devices 2>/dev/null | "$GREP_CMD" -q 'emulator\|device'; then
-  echo "
-    #---- Mobile ADB Shell Enabled ----#
- "
-fi
+adb devices | "$GREP_CMD" -q 'emulator\|device' && echo -e "\n    #---- Mobile ADB Shell Enabled ----#\n"
 
-# Cleanup temporary files
+# Cleanup and launch
 rm -f ~/adbip.txt ~/adbport.txt
-
-# Launch ADB shell
 adb shell

--- a/bin/tools
+++ b/bin/tools
@@ -21,11 +21,7 @@ _shell=${BASH_VERSION:+bash}
 list_execs() {
   local show_path=0 allow_dupe=0
   while getopts ":pa" o; do
-    case $o in
-    p) show_path=1 ;;
-    a) allow_dupe=1 ;;
-    *) die "Bad flag: -$OPTARG" ;;
-    esac
+    case $o in p) show_path=1;; a) allow_dupe=1;; *) die "Bad flag: -$OPTARG";; esac
   done
   shift $((OPTIND - 1))
 
@@ -33,37 +29,21 @@ list_execs() {
   local -a path_arr out=()
   local -A seen
   read -ra path_arr <<<"$PATH"
+  shopt -s nullglob
 
   for d in "${path_arr[@]}"; do
-    [[ -z $d ]] && d=.
-    # Use more efficient globbing with nullglob enabled
-    shopt -s nullglob
-    for f in "$d"/* "$d"/..?*; do
+    for f in "${d:-.}"/* "${d:-.}"/..?*; do
       [[ -f $f && -x $f ]] || continue
       base=${f##*/}
 
-      # Skip based on duplication settings
-      if [[ $allow_dupe -eq 0 ]]; then
-        if [[ $show_path -eq 1 ]]; then
-          [[ -n ${seen["$f"]:-} ]] && continue
-          seen["$f"]=1
-          out+=("$f")
-        else
-          [[ -n ${seen["$base"]:-} ]] && continue
-          seen["$base"]=1
-          out+=("$base")
-        fi
-      else
-        if [[ $show_path -eq 1 ]]; then
-          out+=("$f")
-        else
-          out+=("$base")
-        fi
+      # Add to output if not filtering duplicates or if not seen
+      if [[ $allow_dupe -eq 1 ]] || [[ -z ${seen[$([[ $show_path -eq 1 ]] && echo "$f" || echo "$base")]:-} ]]; then
+        [[ $allow_dupe -eq 0 ]] && seen[$([[ $show_path -eq 1 ]] && echo "$f" || echo "$base")]=1
+        out+=("$([[ $show_path -eq 1 ]] && echo "$f" || echo "$base")")
       fi
     done
-    shopt -u nullglob
   done
-
+  shopt -u nullglob
   printf '%s\n' "${out[@]}"
 }
 
@@ -78,32 +58,15 @@ cht() {
   local update=0 list_only=0
   while [[ $# -gt 0 ]]; do
     case $1 in
-    --update)
-      update=1
-      shift
-      ;;
-    --list)
-      list_only=1
-      shift
-      ;;
-    -h)
-      cat <<E
-cht [--update|--list] [topic] [query...]
-E
-      return 0
-      ;;
-    *) break ;;
+    --update) update=1; shift;;
+    --list) list_only=1; shift;;
+    -h) echo "cht [--update|--list] [topic] [query...]"; return 0;;
+    *) break;;
     esac
   done
 
-  if ((update)) || [[ ! -f $CHT_SH_LIST_CACHE ]]; then
-    log "Updating cache..."
-    _cht_dl || return 1
-  fi
-  ((list_only)) && {
-    cat "$CHT_SH_LIST_CACHE"
-    return 0
-  }
+  ((update)) || [[ ! -f $CHT_SH_LIST_CACHE ]] && { log "Updating cache..."; _cht_dl || return 1; }
+  ((list_only)) && { cat "$CHT_SH_LIST_CACHE"; return 0; }
 
   local topic=$1
   [[ -n ${topic:-} ]] && shift || :
@@ -175,39 +138,16 @@ netlist() {
   local quiet=0 do_speed=1 size_mb=10 region=""
   while [[ $# -gt 0 ]]; do
     case $1 in
-    -q)
-      quiet=1
-      shift
-      ;;
-    --no-speed)
-      do_speed=0
-      shift
-      ;;
-    --size)
-      size_mb=$2
-      shift 2
-      ;;
-    --region)
-      region=$2
-      shift 2
-      ;;
-    -h)
-      cat <<E
-netlist [-q] [--no-speed] [--size MB] [--region R]
-E
-      return 0
-      ;;
-    *)
-      warn "Unused: $1"
-      shift
-      ;;
+    -q) quiet=1; shift;;
+    --no-speed) do_speed=0; shift;;
+    --size) size_mb=$2; shift 2;;
+    --region) region=$2; shift 2;;
+    -h) echo "netlist [-q] [--no-speed] [--size MB] [--region R]"; return 0;;
+    *) warn "Unused: $1"; shift;;
     esac
   done
 
-  has curl || {
-    die "curl required"
-    return 1
-  }
+  has curl || { die "curl required"; return 1; }
 
   local ip
   ip=$(curl -fsSL https://api.ipify.org/ || echo "?")


### PR DESCRIPTION
Streamlined all setup and utility scripts for better readability and maintainability:

- setup.sh: Remove duplicate mkdir, simplify font installation with command chaining, consolidate bootstrap_dotfiles logic
- bin/clean: Extract fd/find pattern into rm_files helper, reduce WhatsApp/Telegram function duplication
- bin/rxfetch: Condense color definitions, replace functions with direct assignments, reduce from 87 to 50 lines
- bin/supershell: Consolidate repetitive adb commands using loop
- bin/tools: Simplify list_execs logic, condense option parsing in cht and netlist functions
- bin/media-opt: Streamline function exports, simplify codec detection with loop

Overall: -170 lines (301 deletions, 131 additions) across 6 files with no functional changes.