### PR TITLE
Complete TODO: Install Dbin package manager

### DIFF
--- a/TODO.MD
+++ b/TODO.MD
@@ -6,9 +6,6 @@ wget -q https://raw.githubusercontent.com/ivan-hc/AM/main/AM-INSTALLER && chmod 
 ```
 
 
-[Dbin](https://github.com/xplshn/dbin)
+~~[Dbin](https://github.com/xplshn/dbin)~~ ✓ Installed
 - package manager for static binaries
-
-```bash
-wget -qO- "https://raw.githubusercontent.com/xplshn/dbin/master/stubdl" | sh -s -- --install "$HOME/.local/bin/dbin"
-```
+- Installed at: `$HOME/.local/bin/dbin`


### PR DESCRIPTION
Installed Dbin v1.7 to $HOME/.local/bin/dbin. Updated TODO.MD to mark the task as complete.