### PR TITLE
⚡ Optimize .zshrc: Remove silent execution of fetch tools

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -168,7 +168,6 @@ ifsource ~/.p10k.zsh
 has zoxide && eval "$(zoxide init zsh --cmd cd)"
 has thefuck && eval "$(thefuck --alias)"
 has mise && eval "$(mise activate zsh)"
-if [[ -o INTERACTIVE && -t 2 ]]; then { has fastfetch && fastfetch || has neofetch && neofetch; } &>/dev/null; fi >&2
 
 # Smart precompile
 (){ local zcompdir="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/zcomp"; ensure_dir "$zcompdir"


### PR DESCRIPTION
💡 **What:**
Removed the line:
`if [[ -o INTERACTIVE && -t 2 ]]; then { has fastfetch && fastfetch || has neofetch && neofetch; } &>/dev/null; fi >&2`
from `.zshrc`.

🎯 **Why:**
This line was executing `fastfetch` or `neofetch` and then discarding all output (`&>/dev/null`). This caused unnecessary overhead during shell startup without providing any visible benefit to the user.

📊 **Measured Improvement:**
(No benchmarks were possible due to missing `zsh`/`fastfetch` binaries in the environment, but the removal of a command that performs work and discards the result is an absolute performance gain.)

---
*PR created automatically by Jules for task [11252723762670678631](https://jules.google.com/task/11252723762670678631) started by @Ven0m0*