### PR TITLE
🧹 Configure keystore and passwords via environment variables

### DIFF
--- a/bin/antisplit.sh
+++ b/bin/antisplit.sh
@@ -33,7 +33,11 @@ log "Output: $SIGNED"
 
 [[ ! -f "$INPUT" ]] && err "File not found: $INPUT"
 
-KEYSTORE="key/antisplit.keystore"
+# Configuration - customizable via environment variables
+KEYSTORE="${KEYSTORE:-key/antisplit.keystore}"
+KS_PASS="${KS_PASS:-password}"
+KS_ALIAS="${KS_ALIAS:-antisplit}"
+KEY_PASS="${KEY_PASS:-password}"
 [[ ! -f "$KEYSTORE" ]] && err "Keystore not found: $KEYSTORE"
 
 log "Merging split files..."
@@ -44,8 +48,8 @@ else
 fi
 
 log "Signing APK..."
-if apksigner sign --ks "$KEYSTORE" --ks-pass "pass:password" \
-    --ks-key-alias "antisplit" --key-pass "pass:password" \
+if apksigner sign --ks "$KEYSTORE" --ks-pass "pass:$KS_PASS" \
+    --ks-key-alias "$KS_ALIAS" --key-pass "pass:$KEY_PASS" \
     --out "$SIGNED" "$OUTPUT"; then
     log "Signed successfully: $SIGNED"
     rm -f "$OUTPUT" "$INPUT_DIR"/*.idsig 

--- a/tests/test_antisplit_health.sh
+++ b/tests/test_antisplit_health.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+set -euo pipefail
+
+# Setup mocks
+export MOCK_DIR=$(mktemp -d)
+export PATH="$MOCK_DIR:$PATH"
+
+# Mock apkeditor
+cat << "MOCK" > "$MOCK_DIR/apkeditor"
+#!/bin/bash
+exit 0
+MOCK
+chmod +x "$MOCK_DIR/apkeditor"
+
+# Mock apksigner
+cat << "MOCK" > "$MOCK_DIR/apksigner"
+#!/bin/bash
+echo "$@" > "$MOCK_DIR/apksigner.args"
+shift
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--out" ]]; then
+    touch "$2"
+  fi
+  shift
+done
+exit 0
+MOCK
+chmod +x "$MOCK_DIR/apksigner"
+
+TEST_DIR=$(mktemp -d)
+INPUT_APK="$TEST_DIR/app.apks"
+touch "$INPUT_APK"
+KEY_DIR="$TEST_DIR/key"
+mkdir -p "$KEY_DIR"
+KEYSTORE="$KEY_DIR/antisplit.keystore"
+touch "$KEYSTORE"
+
+# Use absolute path for bin/antisplit.sh
+SCRIPT_PATH="$(pwd)/bin/antisplit.sh"
+
+echo "=== Test 1: Defaults ==="
+# Unset variables just in case
+unset KEYSTORE KS_PASS KS_ALIAS KEY_PASS
+
+# Run in subshell to isolate env
+(
+    cd "$TEST_DIR"
+    bash "$SCRIPT_PATH" "app.apks" >/dev/null 2>&1
+)
+
+ARGS=$(cat "$MOCK_DIR/apksigner.args")
+echo "ARGS: $ARGS"
+
+if [[ "$ARGS" == *"--ks key/antisplit.keystore"* ]]; then
+    echo "PASS: Default keystore used"
+else
+    echo "FAIL: Expected default keystore, got: $ARGS"
+    exit 1
+fi
+if [[ "$ARGS" == *"--ks-pass pass:password"* ]]; then
+    echo "PASS: Default password used"
+else
+    echo "FAIL: Expected default password, got: $ARGS"
+    exit 1
+fi
+
+echo "=== Test 2: Custom Env ==="
+CUSTOM_KEYSTORE="$TEST_DIR/custom.keystore"
+touch "$CUSTOM_KEYSTORE"
+
+(
+    export KEYSTORE="$CUSTOM_KEYSTORE"
+    export KS_PASS="mysecret"
+    export KS_ALIAS="myalias"
+    export KEY_PASS="mykeysecret"
+    cd "$TEST_DIR"
+    bash "$SCRIPT_PATH" "app.apks" >/dev/null 2>&1
+)
+
+ARGS=$(cat "$MOCK_DIR/apksigner.args")
+echo "ARGS: $ARGS"
+
+if [[ "$ARGS" == *"--ks $CUSTOM_KEYSTORE"* ]]; then
+    echo "PASS: Custom keystore used"
+else
+    echo "FAIL: Expected custom keystore, got: $ARGS"
+    exit 1
+fi
+if [[ "$ARGS" == *"--ks-pass pass:mysecret"* ]]; then
+    echo "PASS: Custom password used"
+else
+    echo "FAIL: Expected custom password, got: $ARGS"
+    exit 1
+fi
+if [[ "$ARGS" == *"--ks-key-alias myalias"* ]]; then
+    echo "PASS: Custom alias used"
+else
+    echo "FAIL: Expected custom alias, got: $ARGS"
+    exit 1
+fi
+if [[ "$ARGS" == *"--key-pass pass:mykeysecret"* ]]; then
+    echo "PASS: Custom key password used"
+else
+    echo "FAIL: Expected custom key password, got: $ARGS"
+    exit 1
+fi
+
+echo "ALL TESTS PASSED"
+rm -rf "$MOCK_DIR" "$TEST_DIR"


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
- Removed hardcoded keystore password, key password, and keystore path/alias from `bin/antisplit.sh`.

💡 **Why:** How this improves maintainability
- Allows users to secure their signing process by setting passwords in environment variables instead of committing them in scripts.
- Makes the keystore location and alias configurable without editing the script.
- Preserves backward compatibility by defaulting to the previous values if variables are unset.

✅ **Verification:** How you confirmed the change is safe
- Created `tests/test_antisplit_health.sh` to verify both default behavior (hardcoded values preserved as defaults) and custom configuration via environment variables.
- Verified that `apksigner` arguments are correctly passed in both scenarios.
- Linted scripts with `bash -n`.

✨ **Result:** The improvement achieved
- A more secure and flexible `antisplit.sh` script.

---
*PR created automatically by Jules for task [1301239294431827680](https://jules.google.com/task/1301239294431827680) started by @Ven0m0*