### PR TITLE
Refactor setup_mise.sh to use dynamic TERMUX_PREFIX

### DIFF
--- a/setup_mise.sh
+++ b/setup_mise.sh
@@ -1,13 +1,16 @@
-#!/data/data/com.termux/files/usr/bin/bash
+#!/usr/bin/env bash
 # shellcheck enable=all shell=bash source-path=SCRIPTDIR external-sources=true
 set -euo pipefail; shopt -s nullglob globstar
 IFS=$'\n\t' LC_ALL=C DEBIAN_FRONTEND=noninteractive
 s=${BASH_SOURCE[0]}; [[ $s != /* ]] && s=$PWD/$s; cd -P -- "${s%/*}"
+
+readonly TERMUX_PREFIX="${PREFIX:-/data/data/com.termux/files/usr}"
+
 has(){ command -v -- "$1" &>/dev/null; }
 log(){ printf '[INFO] %s\n' "$*"; }
 die(){ printf '[ERROR] %s\n' "$*" >&2; exit 1; }
 fetch_key(){
-  local keyring=/data/data/com.termux/files/usr/etc/apt/keyrings/mise-archive-keyring.gpg
+  local keyring="${TERMUX_PREFIX}/etc/apt/keyrings/mise-archive-keyring.gpg"
   install -dm 755 "${keyring%/*}"
   if has curl; then
     curl -fsSL https://mise.jdx.dev/gpg-key.pub | gpg --dearmor >"$keyring"
@@ -18,10 +21,11 @@ fetch_key(){
   fi
 }
 write_sources(){
-  local list=/data/data/com.termux/files/usr/etc/apt/sources.list.d/mise.list
-  cat >"$list" <<'EOF'
-deb [signed-by=/data/data/com.termux/files/usr/etc/apt/keyrings/mise-archive-keyring.gpg arch=arm64] https://mise.jdx.dev/deb stable main
-EOF
+  local list="${TERMUX_PREFIX}/etc/apt/sources.list.d/mise.list"
+  install -dm 755 "${list%/*}"
+  cat >"$list" <<INNEREOF
+deb [signed-by=${TERMUX_PREFIX}/etc/apt/keyrings/mise-archive-keyring.gpg arch=arm64] https://mise.jdx.dev/deb stable main
+INNEREOF
 }
 main(){
   pkg update -y; pkg install -y wget curl gpg
@@ -29,4 +33,7 @@ main(){
   pkg update -y; pkg install -y mise
   log "mise installed"
 }
-main "$@"
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi


### PR DESCRIPTION
Refactor setup_mise.sh to use dynamic TERMUX_PREFIX

- Replaced hardcoded `/data/data/com.termux/files/usr` paths with `${TERMUX_PREFIX}` which defaults to the standard path but respects `$PREFIX`.
- Updated shebang to `#!/usr/bin/env bash` for better portability.
- Added `install -dm 755` to `write_sources` to ensure the directory exists before writing.
- Added `if [[ "${BASH_SOURCE[0]}" == "${0}" ]]` guard to allow sourcing the script for testing.
- Verified with a temporary test script mocking `pkg`, `curl`, `gpg`, and `install`.

---
*PR created automatically by Jules for task [18258810760875332572](https://jules.google.com/task/18258810760875332572) started by @Ven0m0*